### PR TITLE
Debug mode updates

### DIFF
--- a/include/ltio.h
+++ b/include/ltio.h
@@ -43,9 +43,10 @@ void print_string(WORD* mem, ADDRESS start, ADDRESS max);
 void read_string(WORD* mem, ADDRESS start, ADDRESS max);
 
 /* Main debugging function. Shows the state of the stack and the current op
- * along with some pointers.
+ * along with some pointers. Also asks for a step, and will not stop until the
+ * given number of addresses have been run.
  */
-void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
-                        ADDRESS rsp, ADDRESS pc, WORD op);
+size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op, size_t skip);
 
 #endif

--- a/include/ltio.h
+++ b/include/ltio.h
@@ -42,4 +42,10 @@ void print_string(WORD* mem, ADDRESS start, ADDRESS max);
  */
 void read_string(WORD* mem, ADDRESS start, ADDRESS max);
 
+/* Main debugging function. Shows the state of the stack and the current op
+ * along with some pointers.
+ */
+void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op);
+
 #endif

--- a/include/ltio.h
+++ b/include/ltio.h
@@ -2,6 +2,8 @@
 #define LT_64_IO_H
 
 #include "ltconst.h"
+#include "ltrun.h"
+#include "stdio.h"
 #include "stddef.h"
 
 /* Read the bytes of the program from the given file into the given memory
@@ -41,6 +43,10 @@ void print_string(WORD* mem, ADDRESS start, ADDRESS max);
  * input needs to be read.
  */
 void read_string(WORD* mem, ADDRESS start, ADDRESS max);
+
+/* Displays the name of a given op code to the given stream.
+ */
+void display_op_name(OP_CODE op, FILE* stream);
 
 /* Main debugging function. Shows the state of the stack and the current op
  * along with some pointers. Also asks for a step, and will not stop until the

--- a/include/ltio.h
+++ b/include/ltio.h
@@ -49,10 +49,16 @@ void read_string(WORD* mem, ADDRESS start, ADDRESS max);
 void display_op_name(OP_CODE op, FILE* stream);
 
 /* Main debugging function. Shows the state of the stack and the current op
- * along with some pointers. Also asks for a step, and will not stop until the
- * given number of addresses have been run.
+ * along with some pointers.
  */
-size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
-                        ADDRESS rsp, ADDRESS pc, WORD op, size_t skip);
+void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op);
+
+/* If steps is 0 it will pause and ask for a steps value. Pressing enter without
+ * a value will pause again on the next call. Giving a value will return that
+ * value. If called with a non-zero steps count will not pause and will
+ * return the steps - 1.
+ */
+size_t debug_step(size_t steps);
 
 #endif

--- a/include/ltrun.h
+++ b/include/ltrun.h
@@ -9,7 +9,7 @@
  * VM will still run fine if they are rearanged, but the tests depend on the
  * current code assignment.
  */
-enum op_codes { HALT=0,
+typedef enum op_codes { HALT=0,
   PUSH, POP, LOAD, STORE,  // 04
   FST, SEC, NTH,  // 07
   SWAP, ROT,  // 09
@@ -50,7 +50,7 @@ enum op_codes { HALT=0,
   FMULT, FDIV, FMULTSC, FDIVSC,  // 63
 
   PRNPK,
-};
+} OP_CODE;
 
 // Some additional codes to track the direction of memory copies
 enum copy_codes { MEM_BUF = 0, BUF_MEM };

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -35,7 +35,7 @@ size_t read_program(WORD* mem, const char* filename) {
 void display_range(WORD* mem, ADDRESS start, ADDRESS end, bool debug) {
   for (ADDRESS i = start; i < end; i++) {
     if (debug)
-      fprintf(stderr, "%04hx ", mem[i]);
+      fprintf(stderr, "%04hx(%hd) ", mem[i], mem[i]);
     else
       printf("%04hx ", mem[i]);
   }
@@ -96,3 +96,12 @@ void read_string(WORD* mem, ADDRESS start, ADDRESS max) {
   mem[atemp + 1] = 0;
 }
 
+void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op) {
+  fprintf(stderr, "Dstack: ");
+  display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
+  fprintf(stderr, "Rstack: ");
+  display_range(return_stack, 0x0001, rsp + 1, DEBUGGING);
+  fprintf(stderr, "OP: %hx (%hu)\nPC: %hx (%hu)\n\n",
+          op, op, pc, pc);
+}

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -191,6 +191,8 @@ void display_op_name(OP_CODE op, FILE* stream) {
     case READSP_unused: fprintf(stream, "READSP_unused"); break;
     case HIGH: fprintf(stream, "HIGH"); break;
     case LOW: fprintf(stream, "LOW"); break;
+    case BFSTORE: fprintf(stream, "BFSTORE"); break;
+    case BFLOAD: fprintf(stream, "BFLOAD"); break;
     case UNPACK: fprintf(stream, "UNPACK"); break;
     case PACK: fprintf(stream, "PACK"); break;
     case MEMCOPY: fprintf(stream, "MEMCOPY"); break;
@@ -204,25 +206,26 @@ void display_op_name(OP_CODE op, FILE* stream) {
   }
 }
 
-size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
-                        ADDRESS rsp, ADDRESS pc, WORD op, size_t skip) {
+void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op) {
   // print stacks and pointers
   fprintf(stderr, "Dstack: ");
   display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
   fprintf(stderr, "Rstack: ");
   display_range(return_stack, 0x0001, rsp + 1, DEBUGGING);
-  fprintf(stderr, "PC: %hx (%hu), OP: ", pc, pc);
+  fprintf(stderr, "PC: %hx (%hu), Next OP: ", pc, pc);
   display_op_name(op, stderr);
   fprintf(stderr, "\n\n");
+}
 
-  // deal with step
-  if (skip != 0) {
-    return skip - 1;
+size_t debug_step(size_t steps) {
+  if (steps > 0) {
+    return steps - 1;
   } else {
     char buffer[10];
     int size = 10;
 
-    fprintf(stderr, "*** Enter Step: ");
+    fprintf(stderr, "*** Steps: ");
     if ( fgets(buffer, size, stdin) != NULL ) {
       return atoi(buffer);
     } else {

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -33,15 +33,20 @@ size_t read_program(WORD* mem, const char* filename) {
 }
 
 void display_range(WORD* mem, ADDRESS start, ADDRESS end, bool debug) {
+  if (debug && end - 8 >= start) {
+    start = end - 8;
+    fprintf(stderr, "... ");
+  }
+
   for (ADDRESS i = start; i < end; i++) {
     if (debug)
-      fprintf(stderr, "%04hx(%hd) ", mem[i], mem[i]);
+      fprintf(stderr, "%hx(%hd) ", mem[i], mem[i]);
     else
       printf("%04hx ", mem[i]);
   }
 
   if (debug)
-    fprintf(stderr, "\n");
+    fprintf(stderr, "->\n");
   else
     printf("\n");
 }
@@ -96,12 +101,27 @@ void read_string(WORD* mem, ADDRESS start, ADDRESS max) {
   mem[atemp + 1] = 0;
 }
 
-void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
-                        ADDRESS rsp, ADDRESS pc, WORD op) {
+size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
+                        ADDRESS rsp, ADDRESS pc, WORD op, size_t skip) {
+  // print stacks and pointers
   fprintf(stderr, "Dstack: ");
   display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
   fprintf(stderr, "Rstack: ");
   display_range(return_stack, 0x0001, rsp + 1, DEBUGGING);
-  fprintf(stderr, "OP: %hx (%hu)\nPC: %hx (%hu)\n\n",
-          op, op, pc, pc);
+  fprintf(stderr, "OP: %hx (%hu)\nPC: %hx (%hu)\n\n", op, op, pc, pc);
+
+  // deal with step
+  if (skip != 0) {
+    return skip - 1;
+  } else {
+    char buffer[10];
+    int size = 10;
+
+    fprintf(stderr, "*** Enter Step: ");
+    if ( fgets(buffer, size, stdin) != NULL ) {
+      return atoi(buffer);
+    } else {
+      return 0;
+    }
+  }
 }

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -34,7 +34,7 @@ size_t read_program(WORD* mem, const char* filename) {
 }
 
 void display_range(WORD* mem, ADDRESS start, ADDRESS end, bool debug) {
-  if (debug && end - 8 >= start) {
+  if (debug && end - 8 > start) {
     start = end - 8;
     fprintf(stderr, "... ");
   }
@@ -185,6 +185,10 @@ void display_op_name(OP_CODE op, FILE* stream) {
     case PRNLN: fprintf(stream, "PRNLN"); break;
     case PRNSP_unused: fprintf(stream, "PRNSP_unused"); break;
     case PRNMEM: fprintf(stream, "PRNMEM"); break;
+    case WREAD: fprintf(stream, "WREAD"); break;
+    case DREAD: fprintf(stream, "DREAD"); break;
+    case FREAD: fprintf(stream, "FREAD"); break;
+    case FREADSC: fprintf(stream, "FREADSC"); break;
     case READCH: fprintf(stream, "READCH"); break;
     case READ_unused: fprintf(stream, "READ_unused"); break;
     case READLN: fprintf(stream, "READLN"); break;
@@ -209,6 +213,7 @@ void display_op_name(OP_CODE op, FILE* stream) {
 void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
                         ADDRESS rsp, ADDRESS pc, WORD op) {
   // print stacks and pointers
+  fflush(stdout);
   fprintf(stderr, "Dstack: ");
   display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
   fprintf(stderr, "Rstack: ");
@@ -225,7 +230,8 @@ size_t debug_step(size_t steps) {
     char buffer[10];
     int size = 10;
 
-    fprintf(stderr, "*** Steps: ");
+    fflush(stdout);
+    fprintf(stderr, "  ***Step: ");
     if ( fgets(buffer, size, stdin) != NULL ) {
       return atoi(buffer);
     } else {

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -1,4 +1,5 @@
 #include "ltconst.h"
+#include "ltrun.h"
 #include "stdlib.h"
 #include "stdio.h"
 #include "stdbool.h"
@@ -101,6 +102,108 @@ void read_string(WORD* mem, ADDRESS start, ADDRESS max) {
   mem[atemp + 1] = 0;
 }
 
+// this is formated this way to keep it from taking up 300 lines
+void display_op_name(OP_CODE op, FILE* stream) {
+  switch (op) {
+    case HALT: fprintf(stream, "HALT"); break;
+    case PUSH: fprintf(stream, "PUSH"); break;
+    case POP: fprintf(stream, "POP"); break;
+    case LOAD: fprintf(stream, "LOAD"); break;
+    case STORE: fprintf(stream, "STORE"); break;
+    case FST: fprintf(stream, "FST"); break;
+    case SEC: fprintf(stream, "SEC"); break;
+    case NTH: fprintf(stream, "NTH"); break;
+    case SWAP: fprintf(stream, "SWAP"); break;
+    case ROT: fprintf(stream, "ROT"); break;
+    case RPUSH: fprintf(stream, "RPUSH"); break;
+    case RPOP: fprintf(stream, "RPOP"); break;
+    case RGRAB: fprintf(stream, "RGRAB"); break;
+    case DPUSH: fprintf(stream, "DPUSH"); break;
+    case DPOP: fprintf(stream, "DPOP"); break;
+    case DLOAD: fprintf(stream, "DLOAD"); break;
+    case DSTORE: fprintf(stream, "DSTORE"); break;
+    case DFST: fprintf(stream, "DFST"); break;
+    case DSEC: fprintf(stream, "DSEC"); break;
+    case DNTH: fprintf(stream, "DNTH"); break;
+    case DSWAP: fprintf(stream, "DSWAP"); break;
+    case DROT: fprintf(stream, "DROT"); break;
+    case DRPUSH: fprintf(stream, "DRPUSH"); break;
+    case DRPOP: fprintf(stream, "DRPOP"); break;
+    case DRGRAB: fprintf(stream, "DRGRAB"); break;
+    case ADD: fprintf(stream, "ADD"); break;
+    case SUB: fprintf(stream, "SUB"); break;
+    case MULT: fprintf(stream, "MULT"); break;
+    case DIV: fprintf(stream, "DIV"); break;
+    case MOD: fprintf(stream, "MOD"); break;
+    case EQ: fprintf(stream, "EQ"); break;
+    case LT: fprintf(stream, "LT"); break;
+    case GT: fprintf(stream, "GT"); break;
+    case MULTU: fprintf(stream, "MULTU"); break;
+    case DIVU: fprintf(stream, "DIVU"); break;
+    case MODU: fprintf(stream, "MODU"); break;
+    case LTU: fprintf(stream, "LTU"); break;
+    case GTU: fprintf(stream, "GTU"); break;
+    case SL: fprintf(stream, "SL"); break;
+    case SR: fprintf(stream, "SR"); break;
+    case AND: fprintf(stream, "AND"); break;
+    case OR: fprintf(stream, "OR"); break;
+    case NOT: fprintf(stream, "NOT"); break;
+    case DADD: fprintf(stream, "DADD"); break;
+    case DSUB: fprintf(stream, "DSUB"); break;
+    case DMULT: fprintf(stream, "DMULT"); break;
+    case DDIV: fprintf(stream, "DDIV"); break;
+    case DMOD: fprintf(stream, "DMOD"); break;
+    case DEQ: fprintf(stream, "DEQ"); break;
+    case DLT: fprintf(stream, "DLT"); break;
+    case DGT: fprintf(stream, "DGT"); break;
+    case DMULTU_unused: fprintf(stream, "DMULTU_unused"); break;
+    case DDIVU: fprintf(stream, "DDIVU"); break;
+    case DMODU: fprintf(stream, "DMODU"); break;
+    case DLTU: fprintf(stream, "DLTU"); break;
+    case DGTU: fprintf(stream, "DGTU"); break;
+    case DSL: fprintf(stream, "DSL"); break;
+    case DSR: fprintf(stream, "DSR"); break;
+    case DAND: fprintf(stream, "DAND"); break;
+    case DOR: fprintf(stream, "DOR"); break;
+    case DNOT: fprintf(stream, "DNOT"); break;
+    case JUMP: fprintf(stream, "JUMP"); break;
+    case BRANCH: fprintf(stream, "BRANCH"); break;
+    case CALL: fprintf(stream, "CALL"); break;
+    case RET: fprintf(stream, "RET"); break;
+    case DSP: fprintf(stream, "DSP"); break;
+    case PC: fprintf(stream, "PC"); break;
+    case BFP: fprintf(stream, "BFP"); break;
+    case FMP: fprintf(stream, "FMP"); break;
+    case WPRN: fprintf(stream, "WPRN"); break;
+    case DPRN: fprintf(stream, "DPRN"); break;
+    case WPRNU: fprintf(stream, "WPRNU"); break;
+    case DPRNU: fprintf(stream, "DPRNU"); break;
+    case FPRN: fprintf(stream, "FPRN"); break;
+    case FPRNSC: fprintf(stream, "FPRNSC"); break;
+    case PRNCH: fprintf(stream, "PRNCH"); break;
+    case PRN: fprintf(stream, "PRN"); break;
+    case PRNLN: fprintf(stream, "PRNLN"); break;
+    case PRNSP_unused: fprintf(stream, "PRNSP_unused"); break;
+    case PRNMEM: fprintf(stream, "PRNMEM"); break;
+    case READCH: fprintf(stream, "READCH"); break;
+    case READ_unused: fprintf(stream, "READ_unused"); break;
+    case READLN: fprintf(stream, "READLN"); break;
+    case READSP_unused: fprintf(stream, "READSP_unused"); break;
+    case HIGH: fprintf(stream, "HIGH"); break;
+    case LOW: fprintf(stream, "LOW"); break;
+    case UNPACK: fprintf(stream, "UNPACK"); break;
+    case PACK: fprintf(stream, "PACK"); break;
+    case MEMCOPY: fprintf(stream, "MEMCOPY"); break;
+    case STRCOPY: fprintf(stream, "STRCOPY"); break;
+    case FMULT: fprintf(stream, "FMULT"); break;
+    case FDIV: fprintf(stream, "FDIV"); break;
+    case FMULTSC: fprintf(stream, "FMULTSC"); break;
+    case FDIVSC: fprintf(stream, "FDIVSC"); break;
+    case PRNPK: fprintf(stream, "PRNPK"); break;
+    default: fprintf(stream, "UNKNOWN=%hx (%hd)", op, op); break;
+  }
+}
+
 size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
                         ADDRESS rsp, ADDRESS pc, WORD op, size_t skip) {
   // print stacks and pointers
@@ -108,7 +211,9 @@ size_t debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
   display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
   fprintf(stderr, "Rstack: ");
   display_range(return_stack, 0x0001, rsp + 1, DEBUGGING);
-  fprintf(stderr, "OP: %hx (%hu)\nPC: %hx (%hu)\n\n", op, op, pc, pc);
+  fprintf(stderr, "PC: %hx (%hu), OP: ", pc, pc);
+  display_op_name(op, stderr);
+  fprintf(stderr, "\n\n");
 
   // deal with step
   if (skip != 0) {

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -71,7 +71,6 @@ void read_string(WORD* mem, ADDRESS start, ADDRESS max) {
   while (atemp < max - 1) {
     char ch;
     scanf("%c", &ch);
-    fprintf(stderr, "%c", ch);
 
     if (ch == '\n') {
       if (first) {

--- a/src/ltio.c
+++ b/src/ltio.c
@@ -220,7 +220,7 @@ void debug_info_display(WORD* data_stack, WORD* return_stack, ADDRESS dsp,
   display_range(return_stack, 0x0001, rsp + 1, DEBUGGING);
   fprintf(stderr, "PC: %hx (%hu), Next OP: ", pc, pc);
   display_op_name(op, stderr);
-  fprintf(stderr, "\n\n");
+  fprintf(stderr, "\n");
 }
 
 size_t debug_step(size_t steps) {
@@ -231,9 +231,9 @@ size_t debug_step(size_t steps) {
     int size = 10;
 
     fflush(stdout);
-    fprintf(stderr, "  ***Step: ");
+    fprintf(stderr, "\n***Step: ");
     if ( fgets(buffer, size, stdin) != NULL ) {
-      return atoi(buffer);
+      return strtol(buffer,NULL,10);
     } else {
       return 0;
     }

--- a/src/ltrun.c
+++ b/src/ltrun.c
@@ -23,10 +23,12 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
   
   // Run the program in memory
   bool run = true;
+  size_t debug_skip = 3;
   while (run) {
     // Print stack, op code, and pc before every execution
     if (DEBUGGING) {
-      debug_info_display(data_stack, return_stack, dsp, rsp, pc, memory[pc]);
+      debug_skip = debug_info_display(data_stack, return_stack, dsp, rsp, pc,
+                                      memory[pc], debug_skip);
     }
 
     // Catch some common pointer/address errors

--- a/src/ltrun.c
+++ b/src/ltrun.c
@@ -26,10 +26,7 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
   while (run) {
     // Print stack, op code, and pc before every execution
     if (DEBUGGING) {
-      fprintf(stderr, "Stack: ");
-      display_range(data_stack, 0x0001, dsp + 1, DEBUGGING);
-      fprintf(stderr, "OP: %hx (%hu)\nPC: %hx (%hu)\n\n",
-              memory[pc], memory[pc], pc, pc);
+      debug_info_display(data_stack, return_stack, dsp, rsp, pc, memory[pc]);
     }
 
     // Catch some common pointer/address errors

--- a/src/ltrun.c
+++ b/src/ltrun.c
@@ -27,7 +27,8 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
   while (run) {
     // Print stack, op code, and pc before every execution
     if (DEBUGGING) {
-      debug_info_display(data_stack, return_stack, dsp, rsp, pc, memory[pc]);
+      debug_steps = debug_step(debug_steps);
+      debug_info_display(data_stack, return_stack, dsp, rsp, pc, memory[pc] & 0xff);
     }
 
     // Catch some common pointer/address errors
@@ -623,9 +624,6 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
         return EXIT_OP;
     }
     pc++;
-
-    if (DEBUGGING)
-      debug_steps = debug_step(debug_steps);
   }
 
   // When program is run for tests we print out the contents of the stack

--- a/src/ltrun.c
+++ b/src/ltrun.c
@@ -23,12 +23,11 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
   
   // Run the program in memory
   bool run = true;
-  size_t debug_skip = 3;
+  size_t debug_steps = 3;
   while (run) {
     // Print stack, op code, and pc before every execution
     if (DEBUGGING) {
-      debug_skip = debug_info_display(data_stack, return_stack, dsp, rsp, pc,
-                                      memory[pc], debug_skip);
+      debug_info_display(data_stack, return_stack, dsp, rsp, pc, memory[pc]);
     }
 
     // Catch some common pointer/address errors
@@ -624,6 +623,9 @@ size_t execute(WORD* memory, size_t length, WORD* data_stack, WORD* return_stack
         return EXIT_OP;
     }
     pc++;
+
+    if (DEBUGGING)
+      debug_steps = debug_step(debug_steps);
   }
 
   // When program is run for tests we print out the contents of the stack


### PR DESCRIPTION
The majority of the work here is to improve the debug mode. This includes:
- Adding a step to the debug process allowing executing only a single instruction at a time or choosing to execute multiple instructions before stopping again.
- Adjusting output to give decimals in brackets next to hex stack values. Helps when the values on the stack are numbers.
- Added function to print the name for each op code. This makes it possible to easily see what the next operation will be rather than having to know/lookup the hex codes.
- Debug steps automatically skip the operations that are just there to jump past the static data section.

Also, updated the README for these changes.